### PR TITLE
use fsnotify.v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Fsmonit
 =======
-Simple wrapper around [fsnotify](https://code.google.com/p/go/source/browse/?repo=exp#hg%2Ffsnotify) to monitor changes in files and folders (including subdirectories created after monitoring has started).
+Simple wrapper around [fsnotify](https://github.com/go-fsnotify/fsnotify) to monitor changes in files and folders (including subdirectories created after monitoring has started).
 
 Example:
 --------

--- a/fsmonitor.go
+++ b/fsmonitor.go
@@ -1,9 +1,10 @@
 package fsmonitor
 
 import (
-	"code.google.com/p/go.exp/fsnotify"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/fsnotify.v0"
 )
 
 func NewWatcher() (*Watcher, error) {


### PR DESCRIPTION
fsnotify is currently being maintained at: https://github.com/go-fsnotify/fsnotify

fsnotify.v0 matches the API you are using but some bugs have been fixed. There
is also a newer v1 API if you wish to upgrade.

(So I know when this is merged, ref: https://github.com/go-fsnotify/fsnotify/issues/35)
