### PR TITLE
fsnotify.v1 support added by shiwork, tests added by me

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,77 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+

--- a/common_test.go
+++ b/common_test.go
@@ -1,11 +1,11 @@
 package fsmonitor
 
 import (
-    "testing"
+	"testing"
 
-    . "gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) {
-    TestingT(t)
+	TestingT(t)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,11 @@
+package fsmonitor
+
+import (
+    "testing"
+
+    . "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+    TestingT(t)
+}

--- a/fsmonitor.go
+++ b/fsmonitor.go
@@ -25,7 +25,7 @@ func NewWatcherWithSkipFolders(skipFolders []string) (*Watcher, error) {
 }
 
 func initWatcher(watcher *fsnotify.Watcher, skipFolders []string) *Watcher {
-	event := make(chan fsnotify.Event)
+	event := make(chan *fsnotify.Event)
 	watcherError := make(chan error)
 	monitorWatcher := &Watcher{Events: event, Error: watcherError, watcher: watcher, SkipFolders: skipFolders}
 	go func() {
@@ -47,6 +47,7 @@ func initWatcher(watcher *fsnotify.Watcher, skipFolders []string) *Watcher {
 						watcher.Remove(ev.Name)
 					}()
 				}
+				monitorWatcher.Events <- &ev
 			case e := <-watcher.Errors:
 				watcherError <- e
 			}
@@ -56,7 +57,7 @@ func initWatcher(watcher *fsnotify.Watcher, skipFolders []string) *Watcher {
 }
 
 type Watcher struct {
-	Events      chan fsnotify.Event
+	Events      chan *fsnotify.Event
 	Error       chan error
 	SkipFolders []string
 	watcher     *fsnotify.Watcher

--- a/fsmonitor.go
+++ b/fsmonitor.go
@@ -1,11 +1,14 @@
 package fsmonitor
 
 import (
-	"github.com/go-fsnotify/fsnotify"
 	"os"
 	"path/filepath"
+
+    "gopkg.in/fsnotify.v1"
 )
 
+// NewWatcher initializes a new watcher which is able to recursively scan
+// the directory structure.
 func NewWatcher() (*Watcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -15,6 +18,8 @@ func NewWatcher() (*Watcher, error) {
 	return monitorWatcher, nil
 }
 
+// NewWatcherWithSkipFolders initializes a new watcher capable of watching
+// for file system events of a recursive directory structure.
 func NewWatcherWithSkipFolders(skipFolders []string) (*Watcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -24,6 +29,7 @@ func NewWatcherWithSkipFolders(skipFolders []string) (*Watcher, error) {
 	return monitorWatcher, nil
 }
 
+// initWatcher starts the underlying watcher interface.
 func initWatcher(watcher *fsnotify.Watcher, skipFolders []string) *Watcher {
 	event := make(chan *fsnotify.Event)
 	watcherError := make(chan error)
@@ -56,6 +62,8 @@ func initWatcher(watcher *fsnotify.Watcher, skipFolders []string) *Watcher {
 	return monitorWatcher
 }
 
+// Watcher is the struct handling the watching of file system events over a recursive
+// directory tree.
 type Watcher struct {
 	Events      chan *fsnotify.Event
 	Error       chan error
@@ -63,14 +71,13 @@ type Watcher struct {
 	watcher     *fsnotify.Watcher
 }
 
+// Watch starts watching the given path and all it's subdirectories for file system
+// changes.
 func (self *Watcher) Watch(path string) error {
-	err := self.watchAllFolders(path)
-	if err != nil {
-		return err
-	}
-	return nil
+	return self.watchAllFolders(path)
 }
 
+// watchAllFolders starts watching all subdirectories via the underlying fsnotify watchers.
 func (self *Watcher) watchAllFolders(path string) (err error) {
 	err = filepath.Walk(path, func(path string, f os.FileInfo, err error) error {
 		if f != nil && f.IsDir() {
@@ -91,10 +98,10 @@ func (self *Watcher) watchAllFolders(path string) (err error) {
 		}
 		return nil
 	})
-	return
+	return err
 }
 
+// addWatcher adds the given path to the underyling fsnotify watcher.
 func (self *Watcher) addWatcher(path string) (err error) {
-	err = self.watcher.Add(path)
-	return
+	return self.watcher.Add(path)
 }

--- a/fsmonitor.go
+++ b/fsmonitor.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-    "gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify.v1"
 )
 
 // NewWatcher initializes a new watcher which is able to recursively scan
@@ -33,38 +33,38 @@ func NewWatcherWithSkipFolders(skipFolders []string) (*Watcher, error) {
 func initWatcher(watcher *fsnotify.Watcher, skipFolders []string) *Watcher {
 	event := make(chan *fsnotify.Event)
 	watcherError := make(chan error)
-    closeChannel := make(chan struct{})
+	closeChannel := make(chan struct{})
 	monitorWatcher := &Watcher{
-        Events: event,
-        Error: watcherError,
-        watcher: watcher,
-        SkipFolders: skipFolders,
-        closeChannel: closeChannel,
-    }
+		Events:       event,
+		Error:        watcherError,
+		watcher:      watcher,
+		SkipFolders:  skipFolders,
+		closeChannel: closeChannel,
+	}
 	go func() {
 		for {
 			select {
-                case ev := <-watcher.Events:
-                    if ev.Op&fsnotify.Create == fsnotify.Create {
-                        go func() {
-                            if f, err := os.Stat(ev.Name); err == nil {
-                                if f.IsDir() {
-                                    monitorWatcher.watchAllFolders(ev.Name)
-                                }
-                            }
+			case ev := <-watcher.Events:
+				if ev.Op&fsnotify.Create == fsnotify.Create {
+					go func() {
+						if f, err := os.Stat(ev.Name); err == nil {
+							if f.IsDir() {
+								monitorWatcher.watchAllFolders(ev.Name)
+							}
+						}
 
-                        }()
-                    }
-                    if ev.Op&fsnotify.Remove == fsnotify.Remove {
-                        go func() {
-                            watcher.Remove(ev.Name)
-                        }()
-                    }
-                    monitorWatcher.Events <- &ev
-                case chanErr := <-watcher.Errors:
-                    watcherError <- chanErr
-                case <-monitorWatcher.closeChannel:
-                    return
+					}()
+				}
+				if ev.Op&fsnotify.Remove == fsnotify.Remove {
+					go func() {
+						watcher.Remove(ev.Name)
+					}()
+				}
+				monitorWatcher.Events <- &ev
+			case chanErr := <-watcher.Errors:
+				watcherError <- chanErr
+			case <-monitorWatcher.closeChannel:
+				return
 			}
 		}
 	}()
@@ -78,7 +78,7 @@ type Watcher struct {
 	Error        chan error
 	SkipFolders  []string
 	watcher      *fsnotify.Watcher
-    closeChannel chan struct{}
+	closeChannel chan struct{}
 }
 
 // Watch starts watching the given path and all it's subdirectories for file system
@@ -118,6 +118,6 @@ func (self *Watcher) addWatcher(path string) error {
 
 // Close stops the internal watcher.
 func (self *Watcher) Close() error {
-    close(self.closeChannel)
-    return self.watcher.Close()
+	close(self.closeChannel)
+	return self.watcher.Close()
 }

--- a/fsmonitor.go
+++ b/fsmonitor.go
@@ -83,16 +83,16 @@ type Watcher struct {
 
 // Watch starts watching the given path and all it's subdirectories for file system
 // changes.
-func (self *Watcher) Watch(path string) error {
-	return self.watchAllFolders(path)
+func (w *Watcher) Watch(path string) error {
+	return w.watchAllFolders(path)
 }
 
 // watchAllFolders starts watching all subdirectories via the underlying fsnotify watchers.
-func (self *Watcher) watchAllFolders(path string) (err error) {
+func (w *Watcher) watchAllFolders(path string) (err error) {
 	err = filepath.Walk(path, func(path string, f os.FileInfo, err error) error {
 		if f != nil && f.IsDir() {
 			filename := f.Name()
-			for _, skipFolder := range self.SkipFolders {
+			for _, skipFolder := range w.SkipFolders {
 				match, err := filepath.Match(skipFolder, filename)
 				if err != nil {
 					return err
@@ -101,7 +101,7 @@ func (self *Watcher) watchAllFolders(path string) (err error) {
 					return filepath.SkipDir
 				}
 			}
-			err := self.addWatcher(path)
+			err := w.addWatcher(path)
 			if err != nil {
 				return err
 			}
@@ -112,12 +112,12 @@ func (self *Watcher) watchAllFolders(path string) (err error) {
 }
 
 // addWatcher adds the given path to the underyling fsnotify watcher.
-func (self *Watcher) addWatcher(path string) error {
-	return self.watcher.Add(path)
+func (w *Watcher) addWatcher(path string) error {
+	return w.watcher.Add(path)
 }
 
 // Close stops the internal watcher.
-func (self *Watcher) Close() error {
-	close(self.closeChannel)
-	return self.watcher.Close()
+func (w *Watcher) Close() error {
+	close(w.closeChannel)
+	return w.watcher.Close()
 }

--- a/fsmonitor.go
+++ b/fsmonitor.go
@@ -40,6 +40,7 @@ func initWatcher(watcher *fsnotify.Watcher, skipFolders []string) *Watcher {
 		watcher:      watcher,
 		SkipFolders:  skipFolders,
 		closeChannel: closeChannel,
+        isClosed:     false,
 	}
 	go func() {
 		for {
@@ -79,6 +80,7 @@ type Watcher struct {
 	SkipFolders  []string
 	watcher      *fsnotify.Watcher
 	closeChannel chan struct{}
+    isClosed     bool
 }
 
 // Watch starts watching the given path and all it's subdirectories for file system
@@ -118,6 +120,14 @@ func (w *Watcher) addWatcher(path string) error {
 
 // Close stops the internal watcher.
 func (w *Watcher) Close() error {
-	close(w.closeChannel)
-	return w.watcher.Close()
+    if(!w.IsClosed()) {
+	    close(w.closeChannel)
+        w.isClosed = true
+    }
+    return w.watcher.Close()
+}
+
+// IsClose returns if the watcher has been closed.
+func (w *Watcher) IsClosed() bool {
+    return w.isClosed
 }

--- a/fsmonitor_test.go
+++ b/fsmonitor_test.go
@@ -1,0 +1,9 @@
+package fsmonitor
+
+import (
+	"testing"
+)
+
+func TestConstructor(t *testing.T) {
+
+}

--- a/fsmonitor_test.go
+++ b/fsmonitor_test.go
@@ -1,9 +1,148 @@
 package fsmonitor
 
 import (
-	"testing"
+    "path/filepath"
+    "io/ioutil"
+    "os"
+
+    "gopkg.in/fsnotify.v1"
+
+    . "gopkg.in/check.v1"
 )
 
-func TestConstructor(t *testing.T) {
+const (
+    // default permissions
+    defaultFilePerms = 0600
+    defaultDirPerms = 0700
+)
 
+type WatcherTests struct {
+    dir string
+    watcher *Watcher
+}
+
+var _ = Suite(&WatcherTests{})
+
+func (t *WatcherTests) SetUpTest(c *C) {
+    t.dir = c.MkDir()
+    watcher, err := NewWatcher()
+    c.Assert(err, IsNil)
+    t.watcher = watcher
+}
+
+func (t *WatcherTests) TearDownTest(c *C) {
+    err := t.watcher.Close()
+    c.Assert(err, IsNil)
+}
+
+func (t *WatcherTests) TestFileCreation(c *C) {
+    err := t.watcher.Watch(t.dir)
+    c.Assert(err, IsNil)
+
+    name := filepath.Join(t.dir, "test.txt")
+    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+    c.Assert(err, IsNil)
+
+    event := <-t.watcher.Events
+    c.Assert(event.Name, Equals, name)
+    c.Assert(event.Op, Equals, fsnotify.Create)
+}
+
+func (t *WatcherTests) TestFileDeletion(c *C) {
+    name := filepath.Join(t.dir, "test.txt")
+    err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+    c.Assert(err, IsNil)
+
+    err = t.watcher.Watch(t.dir)
+    c.Assert(err, IsNil)
+
+    err = os.Remove(name)
+    c.Assert(err, IsNil)
+
+    event := <-t.watcher.Events
+    c.Assert(event.Name, Equals, name)
+    c.Assert(event.Op, Equals, fsnotify.Remove)
+}
+
+func (t *WatcherTests) TestFileModification(c *C) {
+    name := filepath.Join(t.dir, "test.txt")
+    err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+    c.Assert(err, IsNil)
+
+    err = t.watcher.Watch(t.dir)
+    c.Assert(err, IsNil)
+
+    err = ioutil.WriteFile(name, []byte("asdfefadsjklvafh7öafdsü+38"), defaultFilePerms)
+    c.Assert(err, IsNil)
+
+    event := <-t.watcher.Events
+    c.Assert(event.Name, Equals, name)
+    c.Assert(event.Op, Equals, fsnotify.Write)
+}
+
+func (t *WatcherTests) TestFileRename(c *C) {
+    name := filepath.Join(t.dir, "test.txt")
+    err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+    c.Assert(err, IsNil)
+
+    err = t.watcher.Watch(t.dir)
+    c.Assert(err, IsNil)
+
+    newName := filepath.Join(t.dir, "test2.txt")
+    err = os.Rename(name, newName)
+    c.Assert(err, IsNil)
+
+    event := <-t.watcher.Events
+    c.Assert(event.Name, Equals, name)
+    c.Assert(event.Op, Equals, fsnotify.Rename)
+}
+
+func (t *WatcherTests) TestCreateEventInDir(c *C) {
+    dirName := filepath.Join(t.dir, "test")
+    err := os.Mkdir(dirName, defaultDirPerms)
+    c.Assert(err, IsNil)
+
+    err = t.watcher.Watch(t.dir)
+    c.Assert(err, IsNil)
+
+    name := filepath.Join(dirName, "test.txt")
+    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+    c.Assert(err, IsNil)
+
+    event := <-t.watcher.Events
+    c.Assert(event.Name, Equals, name)
+    c.Assert(event.Op, Equals, fsnotify.Create)
+}
+
+func (t *WatcherTests) TestCreateEventInCreatedDir(c *C) {
+    err := t.watcher.Watch(t.dir)
+    c.Assert(err, IsNil)
+
+    dirName := filepath.Join(t.dir, "test")
+    err = os.Mkdir(dirName, defaultDirPerms)
+    c.Assert(err, IsNil)
+
+    event := <-t.watcher.Events
+    c.Assert(event.Name, Equals, dirName)
+    c.Assert(event.Op, Equals, fsnotify.Create)
+
+    name := filepath.Join(dirName, "test.txt")
+    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+    c.Assert(err, IsNil)
+
+    event = <-t.watcher.Events
+    c.Assert(event.Name, Equals, name)
+    c.Assert(event.Op, Equals, fsnotify.Create)
+}
+
+func (t *WatcherTests) TestClose(c *C) {
+    err := t.watcher.Watch(t.dir)
+    c.Assert(err, IsNil)
+
+    err = t.watcher.Close()
+    c.Assert(err, IsNil)
+
+    watcher, err := NewWatcher()
+    c.Assert(err, IsNil)
+    t.watcher = watcher
 }

--- a/fsmonitor_test.go
+++ b/fsmonitor_test.go
@@ -1,199 +1,199 @@
 package fsmonitor
 
 import (
-    "path/filepath"
-    "io/ioutil"
-    "os"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
-    "gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify.v1"
 
-    . "gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 const (
-    // default permissions
-    defaultFilePerms = 0600
-    defaultDirPerms = 0700
+	// default permissions
+	defaultFilePerms = 0600
+	defaultDirPerms  = 0700
 )
 
 type WatcherTests struct {
-    dir string
-    watcher *Watcher
+	dir     string
+	watcher *Watcher
 }
 
 var _ = Suite(&WatcherTests{})
 
 func (t *WatcherTests) SetUpTest(c *C) {
-    t.dir = c.MkDir()
-    watcher, err := NewWatcher()
-    c.Assert(err, IsNil)
-    t.watcher = watcher
+	t.dir = c.MkDir()
+	watcher, err := NewWatcher()
+	c.Assert(err, IsNil)
+	t.watcher = watcher
 }
 
 func (t *WatcherTests) TearDownTest(c *C) {
-    err := t.watcher.Close()
-    c.Assert(err, IsNil)
+	err := t.watcher.Close()
+	c.Assert(err, IsNil)
 }
 
 func (t *WatcherTests) TestFileCreation(c *C) {
-    err := t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err := t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    name := filepath.Join(t.dir, "test.txt")
-    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(t.dir, "test.txt")
+	err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Create)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Create)
 }
 
 func (t *WatcherTests) TestFileDeletion(c *C) {
-    name := filepath.Join(t.dir, "test.txt")
-    err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(t.dir, "test.txt")
+	err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    err = t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err = t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    err = os.Remove(name)
-    c.Assert(err, IsNil)
+	err = os.Remove(name)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Remove)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Remove)
 }
 
 func (t *WatcherTests) TestFileModification(c *C) {
-    name := filepath.Join(t.dir, "test.txt")
-    err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(t.dir, "test.txt")
+	err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    err = t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err = t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    err = ioutil.WriteFile(name, []byte("asdfefadsjklvafh7öafdsü+38"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	err = ioutil.WriteFile(name, []byte("asdfefadsjklvafh7öafdsü+38"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Write)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Write)
 }
 
 func (t *WatcherTests) TestFileRename(c *C) {
-    name := filepath.Join(t.dir, "test.txt")
-    err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(t.dir, "test.txt")
+	err := ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    err = t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err = t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    newName := filepath.Join(t.dir, "test2.txt")
-    err = os.Rename(name, newName)
-    c.Assert(err, IsNil)
+	newName := filepath.Join(t.dir, "test2.txt")
+	err = os.Rename(name, newName)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Rename)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Rename)
 }
 
 func (t *WatcherTests) TestCreateEventInDir(c *C) {
-    dirName := filepath.Join(t.dir, "test")
-    err := os.Mkdir(dirName, defaultDirPerms)
-    c.Assert(err, IsNil)
+	dirName := filepath.Join(t.dir, "test")
+	err := os.Mkdir(dirName, defaultDirPerms)
+	c.Assert(err, IsNil)
 
-    err = t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err = t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    name := filepath.Join(dirName, "test.txt")
-    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(dirName, "test.txt")
+	err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Create)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Create)
 }
 
 func (t *WatcherTests) TestCreateEventInCreatedDir(c *C) {
-    err := t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err := t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    dirName := filepath.Join(t.dir, "test")
-    err = os.Mkdir(dirName, defaultDirPerms)
-    c.Assert(err, IsNil)
+	dirName := filepath.Join(t.dir, "test")
+	err = os.Mkdir(dirName, defaultDirPerms)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, dirName)
-    c.Assert(event.Op, Equals, fsnotify.Create)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, dirName)
+	c.Assert(event.Op, Equals, fsnotify.Create)
 
-    name := filepath.Join(dirName, "test.txt")
-    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(dirName, "test.txt")
+	err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    event = <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Create)
+	event = <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Create)
 }
 
 func (t *WatcherTests) TestDeleteInDir(c *C) {
-    dirName := filepath.Join(t.dir, "test")
-    err := os.Mkdir(dirName, defaultDirPerms)
-    c.Assert(err, IsNil)
+	dirName := filepath.Join(t.dir, "test")
+	err := os.Mkdir(dirName, defaultDirPerms)
+	c.Assert(err, IsNil)
 
-    name := filepath.Join(dirName, "test.txt")
-    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(dirName, "test.txt")
+	err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    err = t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err = t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    err = os.Remove(name)
-    c.Assert(err, IsNil)
+	err = os.Remove(name)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Remove)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Remove)
 }
 
 func (t *WatcherTests) TestDeleteInCreatedDir(c *C) {
-    err := t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err := t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    dirName := filepath.Join(t.dir, "test")
-    err = os.Mkdir(dirName, defaultDirPerms)
-    c.Assert(err, IsNil)
+	dirName := filepath.Join(t.dir, "test")
+	err = os.Mkdir(dirName, defaultDirPerms)
+	c.Assert(err, IsNil)
 
-    event := <-t.watcher.Events
-    c.Assert(event.Name, Equals, dirName)
-    c.Assert(event.Op, Equals, fsnotify.Create)
+	event := <-t.watcher.Events
+	c.Assert(event.Name, Equals, dirName)
+	c.Assert(event.Op, Equals, fsnotify.Create)
 
-    name := filepath.Join(dirName, "test.txt")
-    err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
-    c.Assert(err, IsNil)
+	name := filepath.Join(dirName, "test.txt")
+	err = ioutil.WriteFile(name, []byte("asdf"), defaultFilePerms)
+	c.Assert(err, IsNil)
 
-    event = <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Create)
-    event = <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Write)
+	event = <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Create)
+	event = <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Write)
 
-    err = os.Remove(name)
-    c.Assert(err, IsNil)
+	err = os.Remove(name)
+	c.Assert(err, IsNil)
 
-    event = <-t.watcher.Events
-    c.Assert(event.Name, Equals, name)
-    c.Assert(event.Op, Equals, fsnotify.Remove)
+	event = <-t.watcher.Events
+	c.Assert(event.Name, Equals, name)
+	c.Assert(event.Op, Equals, fsnotify.Remove)
 }
 
 func (t *WatcherTests) TestClose(c *C) {
-    err := t.watcher.Watch(t.dir)
-    c.Assert(err, IsNil)
+	err := t.watcher.Watch(t.dir)
+	c.Assert(err, IsNil)
 
-    err = t.watcher.Close()
-    c.Assert(err, IsNil)
+	err = t.watcher.Close()
+	c.Assert(err, IsNil)
 
-    watcher, err := NewWatcher()
-    c.Assert(err, IsNil)
-    t.watcher = watcher
+	watcher, err := NewWatcher()
+	c.Assert(err, IsNil)
+	t.watcher = watcher
 }

--- a/fsmonitor_test.go
+++ b/fsmonitor_test.go
@@ -190,8 +190,10 @@ func (t *WatcherTests) TestClose(c *C) {
 	err := t.watcher.Watch(t.dir)
 	c.Assert(err, IsNil)
 
+    c.Assert(t.watcher.IsClosed(), Equals, false)
 	err = t.watcher.Close()
 	c.Assert(err, IsNil)
+    c.Assert(t.watcher.IsClosed(), Equals, true)
 
 	watcher, err := NewWatcher()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Generic tests added and go fmt & golint fixes done.

This pull request would support the newer "v1" interface for fsnotify. Also I added a Close() method to be able to completely close the underlying watcher.

To verify if the watcher is closed a "IsClosed()" function has also been added.
